### PR TITLE
Fix CI macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,25 @@ PYTHON3?=python3
 # All platforms need these object files
 FILES=$(addprefix src/,operations.o packet.o enums.o data.o enum_dump.o util.o canon.o liveview.o bind.o)
 
+CFLAGS = -Isrc/ -I../mjs/ -DVERBOSE -Wall -g -fpic
+
 # Basic support for MinGW and libwpd
 ifdef WIN
   FILES+=src/libwpd.o
   CC=x86_64-w64-mingw32-gcc
   LDFLAGS=-lhid -lole32 -luser32 -lgdi32 -luuid libwpd.dll
 else
-  CFLAGS=$(shell pkg-config --cflags --libs libusb-1.0)
+  CFLAGS += $(shell pkg-config --cflags libusb-1.0)
+  LDFLAGS += $(shell pkg-config --libs libusb-1.0)
   FILES+=src/libusb.o src/backend.o
 endif
 
-CFLAGS+=-Isrc/ -I../mjs/ -DVERBOSE -Wall -g -fpic
 
 # TODO: implement as CAMLIB_VERSION
 COMMIT=$(shell git rev-parse HEAD)
 
 libcl.so: $(FILES)
-	$(CC) -shared $(FILES) -o libcl.so
+	$(CC) $(CFLAGS) $(LDFLAGS) -shared $(FILES) -o libcl.so
 
 %.o: %.c src/*.h
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/src/backend.c
+++ b/src/backend.c
@@ -91,7 +91,7 @@ int ptp_fsend_packets(struct PtpRuntime *r, int length, FILE *stream) {
 			return PTP_IO_ERR;
 		}
 
-		int x = ptp_send_bulk_packet(r->data, x);
+		x = ptp_send_bulk_packet(r->data, x);
 		if (x < 0) {
 			PTPLOG("send_bulk_packet: %d\n", x);
 			return PTP_IO_ERR;

--- a/src/data.c
+++ b/src/data.c
@@ -212,8 +212,8 @@ int ptp_storage_info_json(struct PtpStorageInfo *so, char *buffer, int max) {
 	int len = sprintf(buffer, "{");
 	len += snprintf(buffer + len, max - len, "\"storage_type\": \"%s\",", eval_storage_type(so->storage_type));
 	len += snprintf(buffer + len, max - len, "\"fs_type\": %u,", so->fs_type);
-	len += snprintf(buffer + len, max - len, "\"max_capacity\": %lu,", so->max_capacity);
-	len += snprintf(buffer + len, max - len, "\"free_space\": %lu", so->free_space);
+	len += snprintf(buffer + len, max - len, "\"max_capacity\": %llu,", so->max_capacity);
+	len += snprintf(buffer + len, max - len, "\"free_space\": %llu", so->free_space);
 	len += snprintf(buffer + len, max - len, "}");
 	return len;
 }


### PR DESCRIPTION
This should fix the failing CI in macOS.

Also include a couple of small fixes that shouldn't affect it's overall functionality.
The changes on the Makefile also silences a lot of annoying warnings from clang.