### PR TITLE
Improve shared library creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ PYTHON3?=python3
 FILES=$(addprefix src/,operations.o packet.o enums.o data.o enum_dump.o util.o canon.o liveview.o bind.o)
 
 CFLAGS = -Isrc/ -I../mjs/ -DVERBOSE -Wall -g -fpic
+SONAME = libcl.so
 
 # Basic support for MinGW and libwpd
 ifdef WIN
@@ -24,7 +25,7 @@ endif
 COMMIT=$(shell git rev-parse HEAD)
 
 libcl.so: $(FILES)
-	$(CC) $(CFLAGS) $(LDFLAGS) -shared $(FILES) -o libcl.so
+	$(CC) -shared -Wl,-soname,$(SONAME) $(FILES) $(LDFLAGS) -o $(SONAME)
 
 %.o: %.c src/*.h
 	$(CC) -c $(CFLAGS) $< -o $@


### PR DESCRIPTION
This approach creates a shared library with SONAME included and a dependency to libusb-1.0:

> readelf -d ./libcl.so
> 
> Dynamic section at offset 0x11d98 contains 26 entries:
>   Tag        Type                         Name/Value
>  0x0000000000000001 (NEEDED)             Shared library: [libusb-1.0.so.0]
>  0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
>  0x000000000000000e (SONAME)             Library soname: [libcl.so]
>  