### PR TITLE
Added Dynamic Library for Windows; Using Winsock under Windows

### DIFF
--- a/lib/lc_main.cpp
+++ b/lib/lc_main.cpp
@@ -1,0 +1,42 @@
+#define BUILD_DLL
+#define CAMLIB_INCLUDE_IMPL
+
+#include "lc_main.h"
+#include <stdio.h>
+#include <stdint.h>
+#include <pthread.h>
+#include <libusb.h>
+#include <camlib.h>
+
+/*
+#include <lib.c>
+#include <libusb.c>
+#include <log.c>
+#include <no_ip.c>            //Include CygWin Library under Windows
+#include <packet.c>
+#include <transport.c>
+*/
+
+extern "C" DLL_EXPORT BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+{
+    switch (fdwReason)
+    {
+        case DLL_PROCESS_ATTACH:
+            // attach to process
+            // return FALSE to fail DLL load
+            break;
+
+        case DLL_PROCESS_DETACH:
+            // detach from process
+            break;
+
+        case DLL_THREAD_ATTACH:
+            // attach to thread
+            break;
+
+        case DLL_THREAD_DETACH:
+            // detach from thread
+            break;
+    }
+    return TRUE; // succesful
+}

--- a/lib/lc_main.h
+++ b/lib/lc_main.h
@@ -1,0 +1,6 @@
+#ifndef __LC_MAIN_H__
+#define __LC_MAIN_H__
+
+#include <windows.h>
+
+#endif // __LC_MAIN_H__

--- a/lib/libcamlib.cbp
+++ b/lib/libcamlib.cbp
@@ -46,7 +46,11 @@
 		</Compiler>
 		<Linker>
 			<Add library="../../libusb/MinGW64/static/libusb-1.0.dll.a" />
+			<Add library="libws2_32.a" />
 		</Linker>
+		<Unit filename="../src/ip.c">
+			<Option compilerVar="CC" />
+		</Unit>
 		<Unit filename="../src/lib.c">
 			<Option compilerVar="CC" />
 		</Unit>
@@ -54,9 +58,6 @@
 			<Option compilerVar="CC" />
 		</Unit>
 		<Unit filename="../src/log.c">
-			<Option compilerVar="CC" />
-		</Unit>
-		<Unit filename="../src/no_ip.c">
 			<Option compilerVar="CC" />
 		</Unit>
 		<Unit filename="../src/packet.c">

--- a/lib/libcamlib.cbp
+++ b/lib/libcamlib.cbp
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<CodeBlocks_project_file>
+	<FileVersion major="1" minor="6" />
+	<Project>
+		<Option title="libcamlib" />
+		<Option pch_mode="2" />
+		<Option compiler="gcc" />
+		<Build>
+			<Target title="Debug">
+				<Option output="build/bin/Debug/libcamlib" prefix_auto="1" extension_auto="1" />
+				<Option object_output="build/obj/Debug/" />
+				<Option type="3" />
+				<Option compiler="gcc" />
+				<Option createDefFile="1" />
+				<Option createStaticLib="1" />
+				<Compiler>
+					<Add option="-Wall" />
+					<Add option="-DBUILD_DLL" />
+					<Add option="-g" />
+				</Compiler>
+				<Linker>
+					<Add library="user32" />
+				</Linker>
+			</Target>
+			<Target title="Release">
+				<Option output="build/bin/Release/libcamlib" prefix_auto="1" extension_auto="1" />
+				<Option object_output="build/obj/Release/" />
+				<Option type="3" />
+				<Option compiler="gcc" />
+				<Option createDefFile="1" />
+				<Option createStaticLib="1" />
+				<Compiler>
+					<Add option="-Wall" />
+					<Add option="-DBUILD_DLL" />
+					<Add option="-O2" />
+				</Compiler>
+				<Linker>
+					<Add option="-s" />
+					<Add library="user32" />
+				</Linker>
+			</Target>
+		</Build>
+		<Compiler>
+			<Add directory="../src" />
+			<Add directory="../../libusb/include" />
+		</Compiler>
+		<Linker>
+			<Add library="../../libusb/MinGW64/static/libusb-1.0.dll.a" />
+		</Linker>
+		<Unit filename="../src/lib.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/libusb.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/log.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/no_ip.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/packet.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="../src/transport.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="lc_main.cpp" />
+		<Unit filename="lc_main.h" />
+		<Extensions />
+	</Project>
+</CodeBlocks_project_file>

--- a/lib/libcamlib.depend
+++ b/lib/libcamlib.depend
@@ -1,5 +1,5 @@
 # depslib dependency file v1.0
-1724249548 source:c:\programming\vs\camlib\src\lib.c
+1724251954 source:c:\programming\vs\camlib\src\lib.c
 	<stdlib.h>
 	<stdio.h>
 	<string.h>
@@ -31,7 +31,7 @@
 
 1724250163 c:\programming\vs\camlib\src\cl_bind.h
 
-1724248613 source:c:\programming\vs\camlib\src\libusb.c
+1724251968 source:c:\programming\vs\camlib\src\libusb.c
 	<errno.h>
 	<stdio.h>
 	<stdlib.h>
@@ -75,7 +75,7 @@
 	<string.h>
 	<camlib.h>
 
-1724249847 source:c:\programming\vs\camlib\lib\lc_main.cpp
+1724251637 source:c:\programming\vs\camlib\lib\lc_main.cpp
 	"lc_main.h"
 	<stdio.h>
 	<stdint.h>
@@ -83,16 +83,16 @@
 	<libusb.h>
 	<camlib.h>
 	<lib.c>
+	<libusb.c>
 	<log.c>
+	<no_ip.c>
 	<packet.c>
 	<transport.c>
-	<no_ip.c>
-	<libusb.c>
 
-1724248874 c:\programming\vs\camlib\lib\lc_main.h
+1724251214 c:\programming\vs\camlib\lib\lc_main.h
 	<windows.h>
 
-1724249548 c:\programming\vs\camlib\src\lib.c
+1724251954 c:\programming\vs\camlib\src\lib.c
 	<stdlib.h>
 	<stdio.h>
 	<string.h>
@@ -124,7 +124,7 @@
 	<camlib.h>
 	<ptp.h>
 
-1724248613 c:\programming\vs\camlib\src\libusb.c
+1724251968 c:\programming\vs\camlib\src\libusb.c
 	<errno.h>
 	<stdio.h>
 	<stdlib.h>
@@ -134,4 +134,16 @@
 	<ptp.h>
 
 1724248080 c:\programming\vs\camlib\lib\cl_backend.h
+
+1724255376 source:c:\programming\vs\camlib\src\ip.c
+	<stdio.h>
+	<stdlib.h>
+	<string.h>
+	<unistd.h>
+	<fcntl.h>
+	<errno.h>
+	<sys/types.h>
+	<winsock.h>
+	<camlib.h>
+	<ptp.h>
 

--- a/lib/libcamlib.depend
+++ b/lib/libcamlib.depend
@@ -1,0 +1,137 @@
+# depslib dependency file v1.0
+1724249548 source:c:\programming\vs\camlib\src\lib.c
+	<stdlib.h>
+	<stdio.h>
+	<string.h>
+	<camlib.h>
+	<ptp.h>
+
+1724250741 c:\programming\vs\camlib\src\camlib.h
+	<stdio.h>
+	<stdint.h>
+	<pthread.h>
+	"ptp.h"
+	<unistd.h>
+	"cl_data.h"
+	"cl_backend.h"
+	"cl_ops.h"
+	"cl_enum.h"
+	"cl_bind.h"
+
+1724221973 c:\programming\vs\camlib\src\ptp.h
+	<stdint.h>
+
+1724250030 c:\programming\vs\camlib\src\cl_data.h
+
+1724250116 c:\programming\vs\camlib\src\cl_backend.h
+
+1724250353 c:\programming\vs\camlib\src\cl_ops.h
+
+1724250212 c:\programming\vs\camlib\src\cl_enum.h
+
+1724250163 c:\programming\vs\camlib\src\cl_bind.h
+
+1724248613 source:c:\programming\vs\camlib\src\libusb.c
+	<errno.h>
+	<stdio.h>
+	<stdlib.h>
+	<libusb.h>
+	<string.h>
+	<camlib.h>
+	<ptp.h>
+
+1706476649 c:\programming\vs\libusb\include\libusb.h
+	<basetsd.h>
+	<limits.h>
+	<stdint.h>
+	<sys/types.h>
+	<sys/time.h>
+	<time.h>
+	<windows.h>
+	<winsock.h>
+
+1724221973 source:c:\programming\vs\camlib\src\log.c
+	<stdio.h>
+	<stdarg.h>
+	<stdlib.h>
+	<camlib.h>
+
+1724221973 source:c:\programming\vs\camlib\src\no_ip.c
+	<camlib.h>
+	<ptp.h>
+
+1724221973 source:c:\programming\vs\camlib\src\packet.c
+	<stdlib.h>
+	<stdint.h>
+	<string.h>
+	<assert.h>
+	<ptp.h>
+	<camlib.h>
+
+1724221973 source:c:\programming\vs\camlib\src\transport.c
+	<stdio.h>
+	<stdint.h>
+	<stdlib.h>
+	<string.h>
+	<camlib.h>
+
+1724249847 source:c:\programming\vs\camlib\lib\lc_main.cpp
+	"lc_main.h"
+	<stdio.h>
+	<stdint.h>
+	<pthread.h>
+	<libusb.h>
+	<camlib.h>
+	<lib.c>
+	<log.c>
+	<packet.c>
+	<transport.c>
+	<no_ip.c>
+	<libusb.c>
+
+1724248874 c:\programming\vs\camlib\lib\lc_main.h
+	<windows.h>
+
+1724249548 c:\programming\vs\camlib\src\lib.c
+	<stdlib.h>
+	<stdio.h>
+	<string.h>
+	<camlib.h>
+	<ptp.h>
+
+1724221973 c:\programming\vs\camlib\src\log.c
+	<stdio.h>
+	<stdarg.h>
+	<stdlib.h>
+	<camlib.h>
+
+1724221973 c:\programming\vs\camlib\src\packet.c
+	<stdlib.h>
+	<stdint.h>
+	<string.h>
+	<assert.h>
+	<ptp.h>
+	<camlib.h>
+
+1724221973 c:\programming\vs\camlib\src\transport.c
+	<stdio.h>
+	<stdint.h>
+	<stdlib.h>
+	<string.h>
+	<camlib.h>
+
+1724221973 c:\programming\vs\camlib\src\no_ip.c
+	<camlib.h>
+	<ptp.h>
+
+1724248613 c:\programming\vs\camlib\src\libusb.c
+	<errno.h>
+	<stdio.h>
+	<stdlib.h>
+	<libusb.h>
+	<string.h>
+	<camlib.h>
+	<ptp.h>
+
+1724248080 c:\programming\vs\camlib\lib\cl_backend.h
+

--- a/lib/libcamlib.layout
+++ b/lib/libcamlib.layout
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<CodeBlocks_layout_file>
+	<FileVersion major="1" minor="0" />
+	<ActiveTarget name="Release" />
+	<File name="..\src\ip.c" open="1" top="1" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="820" topLine="28" />
+		</Cursor>
+	</File>
+</CodeBlocks_layout_file>

--- a/src/camlib.h
+++ b/src/camlib.h
@@ -1,4 +1,4 @@
-/** \file */ 
+/** \file */
 // Main header file for Camlib
 // Copyright 2022 by Daniel C (https://github.com/petabyt/camlib)
 #ifndef PTP_LIB_H
@@ -21,6 +21,12 @@
 	#include <unistd.h>
 	//int usleep(unsigned int usec);
 	#define CAMLIB_SLEEP(ms) usleep(ms * 1000)
+#endif
+
+#ifdef BUILD_DLL
+    #define DLL_EXPORT __declspec(dllexport)
+#else
+    #define DLL_EXPORT
 #endif
 
 // Logging+panic mechanism, define it yourself or link in log.c
@@ -174,105 +180,105 @@ struct PtpArray {
 /// @brief Returns the return code (RC) currently in the data buffer.
 /// @note Not thread safe.
 /// @memberof PtpRuntime
-int ptp_get_return_code(struct PtpRuntime *r);
+DLL_EXPORT int ptp_get_return_code(struct PtpRuntime *r);
 
 /// @brief Get number of parameters in packet in data buffer
 /// @note Not thread safe.
 /// @memberof PtpRuntime
-int ptp_get_param_length(struct PtpRuntime *r);
+DLL_EXPORT int ptp_get_param_length(struct PtpRuntime *r);
 
 /// @brief Get parameter at index i
 /// @note Not thread safe.
 /// @memberof PtpRuntime
-uint32_t ptp_get_param(struct PtpRuntime *r, int i);
+DLL_EXPORT uint32_t ptp_get_param(struct PtpRuntime *r, int i);
 
 /// @brief Get transaction ID of packet in the data buffer
 /// @note Not thread safe.
 /// @memberof PtpRuntime
-int ptp_get_last_transaction_id(struct PtpRuntime *r);
+DLL_EXPORT int ptp_get_last_transaction_id(struct PtpRuntime *r);
 
 /// @brief Get ptr of packet payload in data buffer, after packet header
 /// @note Not thread safe.
 /// @memberof PtpRuntime
-uint8_t *ptp_get_payload(struct PtpRuntime *r);
+DLL_EXPORT uint8_t *ptp_get_payload(struct PtpRuntime *r);
 
 /// @brief Get length of payload returned by ptp_get_payload
 /// @note Not thread safe.
 /// @memberof PtpRuntime
-int ptp_get_payload_length(struct PtpRuntime *r);
+DLL_EXPORT int ptp_get_payload_length(struct PtpRuntime *r);
 
 /// @brief Allocate new PtpRuntime based on bitfield options - see PtpConnType
 /// @memberof PtpRuntime
-struct PtpRuntime *ptp_new(int options);
+DLL_EXPORT struct PtpRuntime *ptp_new(int options);
 
 /// @brief Reset all session-specific fields of PtpRuntime - both libusb and libwpd backends call
 /// this before establishing connection, so calling this is not required
 /// @memberof PtpRuntime
-void ptp_reset(struct PtpRuntime *r);
+DLL_EXPORT void ptp_reset(struct PtpRuntime *r);
 
 /// @brief Init PtpRuntime locally - uses default recommended settings (USB)
 /// @memberof PtpRuntime
-void ptp_init(struct PtpRuntime *r);
+DLL_EXPORT void ptp_init(struct PtpRuntime *r);
 
 /// @brief Frees PtpRuntime data buffer - doesn't free the actual structure, or device info (yet)
 /// @memberof PtpRuntime
-void ptp_close(struct PtpRuntime *r);
+DLL_EXPORT void ptp_close(struct PtpRuntime *r);
 
 /// @brief Send a command request to the device with no data phase
 /// @memberof PtpRuntime
-int ptp_send(struct PtpRuntime *r, struct PtpCommand *cmd);
+DLL_EXPORT int ptp_send(struct PtpRuntime *r, struct PtpCommand *cmd);
 
 /// @brief Send a command request to the device with a data phase (thread safe)
 /// @memberof PtpRuntime
-int ptp_send_data(struct PtpRuntime *r, struct PtpCommand *cmd, void *data, int length);
+DLL_EXPORT int ptp_send_data(struct PtpRuntime *r, struct PtpCommand *cmd, void *data, int length);
 
 /// @brief Try and get an event from the camera over int endpoint (USB-only)
 /// @memberof PtpRuntime
-int ptp_get_event(struct PtpRuntime *r, struct PtpEventContainer *ec);
+DLL_EXPORT int ptp_get_event(struct PtpRuntime *r, struct PtpEventContainer *ec);
 
 /// @brief Unlock the IO mutex (unless it was kept locked)
 /// @memberof PtpRuntime
-void ptp_mutex_unlock(struct PtpRuntime *r);
+DLL_EXPORT void ptp_mutex_unlock(struct PtpRuntime *r);
 
 /// @brief Keep the mutex locked one more time for the current thread
 /// @note  When calling a thread-safe function, this will garuntee the mutex locked, in the
 /// case that you want to continue using the buffer. Must be unlocked or will cause deadlock.
 /// @note camlib uses a recursive mutex.
 /// @memberof PtpRuntime
-void ptp_mutex_keep_locked(struct PtpRuntime *r);
+DLL_EXPORT void ptp_mutex_keep_locked(struct PtpRuntime *r);
 
 /// @brief Lock the IO mutex - only should be used by backend
 /// @memberof PtpRuntime
-void ptp_mutex_lock(struct PtpRuntime *r);
+DLL_EXPORT void ptp_mutex_lock(struct PtpRuntime *r);
 
 /// @brief Gets type of device from r->di
 /// @returns enum PtpDeviceType
 /// @memberof PtpRuntime
-int ptp_device_type(struct PtpRuntime *r);
+DLL_EXPORT int ptp_device_type(struct PtpRuntime *r);
 
 /// @brief Check if an opcode is supported by looking through supported props in r->di
 /// @returns 1 if yes, 0 if no
 /// @memberof PtpRuntime
-int ptp_check_opcode(struct PtpRuntime *r, int opcode);
+DLL_EXPORT int ptp_check_opcode(struct PtpRuntime *r, int opcode);
 
 /// @brief Check if a property code is supported by looking through supported props in r->di
 /// @returns 1 if yes, 0 if no
 /// @memberof PtpRuntime
-int ptp_check_prop(struct PtpRuntime *r, int code);
+DLL_EXPORT int ptp_check_prop(struct PtpRuntime *r, int code);
 
 /// @brief Mostly for internal use - realloc the data buffer
 /// @note r->data will be reassigned, any old references must be updated
 /// @memberof PtpRuntime
-int ptp_buffer_resize(struct PtpRuntime *r, size_t size);
+DLL_EXPORT int ptp_buffer_resize(struct PtpRuntime *r, size_t size);
 
-int ptp_write_unicode_string(char *dat, char *string);
-int ptp_read_unicode_string(char *buffer, char *dat, int max);
-int ptp_read_utf8_string(void *dat, char *string, int max);
-int ptp_read_string(uint8_t *dat, char *string, int max);
-int ptp_write_string(uint8_t *dat, char *string);
-int ptp_write_utf8_string(void *dat, char *string);
-int ptp_read_uint16_array(uint8_t *dat, uint16_t *buf, int max, int *length);
-int ptp_read_uint16_array_s(uint8_t *bs, uint8_t *be, uint16_t *buf, int max, int *length);
+DLL_EXPORT int ptp_write_unicode_string(char *dat, char *string);
+DLL_EXPORT int ptp_read_unicode_string(char *buffer, char *dat, int max);
+DLL_EXPORT int ptp_read_utf8_string(void *dat, char *string, int max);
+DLL_EXPORT int ptp_read_string(uint8_t *dat, char *string, int max);
+DLL_EXPORT int ptp_write_string(uint8_t *dat, char *string);
+DLL_EXPORT int ptp_write_utf8_string(void *dat, char *string);
+DLL_EXPORT int ptp_read_uint16_array(uint8_t *dat, uint16_t *buf, int max, int *length);
+DLL_EXPORT int ptp_read_uint16_array_s(uint8_t *bs, uint8_t *be, uint16_t *buf, int max, int *length);
 inline static int ptp_write_u8 (void *buf, uint8_t out) { ((uint8_t *)buf)[0] = out; return 1; }
 inline static int ptp_write_u16(void *buf, uint16_t out) { ((uint16_t *)buf)[0] = out; return 2; }
 inline static int ptp_write_u32(void *buf, uint32_t out) { ((uint32_t *)buf)[0] = out; return 4; }
@@ -281,26 +287,26 @@ inline static int ptp_read_u16 (void *buf, uint16_t *out) { *out = ((uint16_t *)
 inline static int ptp_read_u8  (void *buf, uint8_t *out) { *out = ((uint8_t *)buf)[0]; return 1; }
 
 // Build a new PTP/IP or PTP/USB command packet in r->data
-int ptp_new_cmd_packet(struct PtpRuntime *r, struct PtpCommand *cmd);
+DLL_EXPORT int ptp_new_cmd_packet(struct PtpRuntime *r, struct PtpCommand *cmd);
 
 // Only for PTP_USB or PTP_USB_IP use
-int ptp_new_data_packet(struct PtpRuntime *r, struct PtpCommand *cmd, void *data, int data_length);
+DLL_EXPORT int ptp_new_data_packet(struct PtpRuntime *r, struct PtpCommand *cmd, void *data, int data_length);
 
 // Only use for PTP_IP
-int ptpip_data_start_packet(struct PtpRuntime *r, int data_length);
-int ptpip_data_end_packet(struct PtpRuntime *r, void *data, int data_length);
+DLL_EXPORT int ptpip_data_start_packet(struct PtpRuntime *r, int data_length);
+DLL_EXPORT int ptpip_data_end_packet(struct PtpRuntime *r, void *data, int data_length);
 
 // Used only by ptp_open_session
-void ptp_update_transaction(struct PtpRuntime *r, int t);
+DLL_EXPORT void ptp_update_transaction(struct PtpRuntime *r, int t);
 
 // Set avail info for prop
-void ptp_set_prop_avail_info(struct PtpRuntime *r, int code, int memb_size, int cnt, void *data);
+DLL_EXPORT void ptp_set_prop_avail_info(struct PtpRuntime *r, int code, int memb_size, int cnt, void *data);
 
-void *ptp_dup_payload(struct PtpRuntime *r);
+DLL_EXPORT void *ptp_dup_payload(struct PtpRuntime *r);
 
 // Write r->data to a file called DUMP
 /// @note Debugging only
-int ptp_dump(struct PtpRuntime *r);
+DLL_EXPORT int ptp_dump(struct PtpRuntime *r);
 
 #define CAMLIB_INCLUDE_IMPL
 #include "cl_data.h"
@@ -323,11 +329,11 @@ int ptp_dump(struct PtpRuntime *r);
 typedef void ptp_object_found_callback(struct PtpRuntime *r, struct PtpObjectInfo *oi, void *arg);
 
 // Object service api (object.c) - optional
-struct ObjectCache *ptp_create_object_service(int *handles, int length, ptp_object_found_callback *callback, void *arg);
-struct PtpObjectInfo *ptp_object_service_get(struct PtpRuntime *r, struct ObjectCache *oc, int handle);
-struct PtpObjectInfo *ptp_object_service_get_index(struct PtpRuntime *r, struct ObjectCache *oc, int req_i);
-int ptp_object_service_length(struct PtpRuntime *r, struct ObjectCache *oc);
-int ptp_object_service_step(struct PtpRuntime *r, struct ObjectCache *oc);
-void ptp_object_service_add_priority(struct PtpRuntime *r, struct ObjectCache *oc, int handle);
+DLL_EXPORT struct ObjectCache *ptp_create_object_service(int *handles, int length, ptp_object_found_callback *callback, void *arg);
+DLL_EXPORT struct PtpObjectInfo *ptp_object_service_get(struct PtpRuntime *r, struct ObjectCache *oc, int handle);
+DLL_EXPORT struct PtpObjectInfo *ptp_object_service_get_index(struct PtpRuntime *r, struct ObjectCache *oc, int req_i);
+DLL_EXPORT int ptp_object_service_length(struct PtpRuntime *r, struct ObjectCache *oc);
+DLL_EXPORT int ptp_object_service_step(struct PtpRuntime *r, struct ObjectCache *oc);
+DLL_EXPORT void ptp_object_service_add_priority(struct PtpRuntime *r, struct ObjectCache *oc, int handle);
 
 #endif

--- a/src/cl_backend.h
+++ b/src/cl_backend.h
@@ -22,46 +22,46 @@ struct PtpDeviceEntry {
 	struct PtpDeviceEntry *next;
 };
 
-int ptp_comm_init(struct PtpRuntime *r);
-struct PtpDeviceEntry *ptpusb_device_list(struct PtpRuntime *r);
-void ptpusb_free_device_list(struct PtpDeviceEntry *e);
-int ptp_device_open(struct PtpRuntime *r, struct PtpDeviceEntry *entry);
+DLL_EXPORT int ptp_comm_init(struct PtpRuntime *r);
+DLL_EXPORT struct PtpDeviceEntry *ptpusb_device_list(struct PtpRuntime *r);
+DLL_EXPORT void ptpusb_free_device_list(struct PtpDeviceEntry *e);
+DLL_EXPORT int ptp_device_open(struct PtpRuntime *r, struct PtpDeviceEntry *entry);
 
 // Init comm (if not already) and connect to the first device available
-int ptp_device_init(struct PtpRuntime *r);
+DLL_EXPORT int ptp_device_init(struct PtpRuntime *r);
 
 // Temporary :)
 #define ptp_send_bulk_packet DEPRECATED_USE_ptp_cmd_write_INSTEAD
 #define ptp_receive_bulk_packet DEPRECATED_USE_ptp_cmd_read_INSTEAD
 
 // Bare IO, send a single 512 byte packet. Return negative or NULL on error.
-int ptp_cmd_write(struct PtpRuntime *r, void *to, int length);
-int ptp_cmd_read(struct PtpRuntime *r, void *to, int length);
+DLL_EXPORT int ptp_cmd_write(struct PtpRuntime *r, void *to, int length);
+DLL_EXPORT int ptp_cmd_read(struct PtpRuntime *r, void *to, int length);
 
 // Reset the pipe, can clear issues
-int ptp_device_reset(struct PtpRuntime *r);
+DLL_EXPORT int ptp_device_reset(struct PtpRuntime *r);
 
 // Recieve all packets, and whatever else (common logic for all backends)
-int ptp_send_bulk_packets(struct PtpRuntime *r, int length);
-int ptp_receive_bulk_packets(struct PtpRuntime *r);
-int ptp_read_int(struct PtpRuntime *r, void *to, int length);
+DLL_EXPORT int ptp_send_bulk_packets(struct PtpRuntime *r, int length);
+DLL_EXPORT int ptp_receive_bulk_packets(struct PtpRuntime *r);
+DLL_EXPORT int ptp_read_int(struct PtpRuntime *r, void *to, int length);
 
-int ptp_device_close(struct PtpRuntime *r); // TODO: Disconnect, confusing with ptp_close
+DLL_EXPORT int ptp_device_close(struct PtpRuntime *r); // TODO: Disconnect, confusing with ptp_close
 
 // Upload file data as packets, but upload r->data till length first
-int ptp_fsend_packets(struct PtpRuntime *r, int length, FILE *stream);
+DLL_EXPORT int ptp_fsend_packets(struct PtpRuntime *r, int length, FILE *stream);
 
 // Reads the incoming packet to file, starting after an optional offset
-int ptp_freceive_bulk_packets(struct PtpRuntime *r, FILE *stream, int of);
+DLL_EXPORT int ptp_freceive_bulk_packets(struct PtpRuntime *r, FILE *stream, int of);
 
-int ptpip_connect(struct PtpRuntime *r, const char *addr, int port);
-int ptpip_cmd_write(struct PtpRuntime *r, void *data, int size);
-int ptpip_cmd_read(struct PtpRuntime *r, void *data, int size);
+DLL_EXPORT int ptpip_connect(struct PtpRuntime *r, const char *addr, int port);
+DLL_EXPORT int ptpip_cmd_write(struct PtpRuntime *r, void *data, int size);
+DLL_EXPORT int ptpip_cmd_read(struct PtpRuntime *r, void *data, int size);
 
-int ptpip_connect_events(struct PtpRuntime *r, const char *addr, int port);
-int ptpip_event_send(struct PtpRuntime *r, void *data, int size);
-int ptpip_event_read(struct PtpRuntime *r, void *data, int size);
+DLL_EXPORT int ptpip_connect_events(struct PtpRuntime *r, const char *addr, int port);
+DLL_EXPORT int ptpip_event_send(struct PtpRuntime *r, void *data, int size);
+DLL_EXPORT int ptpip_event_read(struct PtpRuntime *r, void *data, int size);
 
-int ptpip_close(struct PtpRuntime *r); // TODO: Disconnect, confusing with ptp_close
+DLL_EXPORT int ptpip_close(struct PtpRuntime *r); // TODO: Disconnect, confusing with ptp_close
 
 #endif

--- a/src/cl_bind.h
+++ b/src/cl_bind.h
@@ -25,11 +25,11 @@ struct BindReq {
 };
 
 // Run a binding - will return JSON
-int bind_run(struct PtpRuntime *r, char *req, char *buffer, int size);
+DLL_EXPORT int bind_run(struct PtpRuntime *r, char *req, char *buffer, int size);
 
 // Run a binding directly from the structure
-int bind_run_req(struct PtpRuntime *r, struct BindReq *bind, char *buffer, int max);
+DLL_EXPORT int bind_run_req(struct PtpRuntime *r, struct BindReq *bind, char *buffer, int max);
 
-void bind_parse(struct BindReq *br, char *req);
+DLL_EXPORT void bind_parse(struct BindReq *br, char *req);
 
 #endif

--- a/src/cl_data.h
+++ b/src/cl_data.h
@@ -163,31 +163,31 @@ enum PtpCHDKCommands {
 #pragma pack(pop)
 
 #ifdef CAMLIB_INCLUDE_IMPL
-int ptp_pack_object_info(struct PtpRuntime *r, struct PtpObjectInfo *oi, uint8_t *buf, int max);
+DLL_EXPORT int ptp_pack_object_info(struct PtpRuntime *r, struct PtpObjectInfo *oi, uint8_t *buf, int max);
 
-int ptp_parse_prop_value(struct PtpRuntime *r);
-int ptp_parse_device_info(struct PtpRuntime *r, struct PtpDeviceInfo *di);
-int ptp_device_info_json(const struct PtpDeviceInfo *di, char *buffer, int max);
-int ptp_parse_prop_desc(struct PtpRuntime *r, struct PtpPropDesc *oi);
-int ptp_prop_desc_json(const struct PtpPropDesc *pd, char *buffer, int max);
-int ptp_parse_object_info(struct PtpRuntime *r, struct PtpObjectInfo *oi);
-int ptp_storage_info_json(const struct PtpStorageInfo *so, char *buffer, int max);
-int ptp_object_info_json(const struct PtpObjectInfo *so, char *buffer, int max);
+DLL_EXPORT int ptp_parse_prop_value(struct PtpRuntime *r);
+DLL_EXPORT int ptp_parse_device_info(struct PtpRuntime *r, struct PtpDeviceInfo *di);
+DLL_EXPORT int ptp_device_info_json(const struct PtpDeviceInfo *di, char *buffer, int max);
+DLL_EXPORT int ptp_parse_prop_desc(struct PtpRuntime *r, struct PtpPropDesc *oi);
+DLL_EXPORT int ptp_prop_desc_json(const struct PtpPropDesc *pd, char *buffer, int max);
+DLL_EXPORT int ptp_parse_object_info(struct PtpRuntime *r, struct PtpObjectInfo *oi);
+DLL_EXPORT int ptp_storage_info_json(const struct PtpStorageInfo *so, char *buffer, int max);
+DLL_EXPORT int ptp_object_info_json(const struct PtpObjectInfo *so, char *buffer, int max);
 
-int ptp_eos_events(struct PtpRuntime *r, struct PtpGenericEvent **p);
-void *ptp_open_eos_events(struct PtpRuntime *r);
-void *ptp_get_eos_event(struct PtpRuntime *r, void *e, struct PtpCanonEvent *ce);
+DLL_EXPORT int ptp_eos_events(struct PtpRuntime *r, struct PtpGenericEvent **p);
+DLL_EXPORT void *ptp_open_eos_events(struct PtpRuntime *r);
+DLL_EXPORT void *ptp_get_eos_event(struct PtpRuntime *r, void *e, struct PtpCanonEvent *ce);
 
-int ptp_eos_events_json(struct PtpRuntime *r, char *buffer, int max);
+DLL_EXPORT int ptp_eos_events_json(struct PtpRuntime *r, char *buffer, int max);
 
 // Standard property value converters (conv.c)
-int ptp_eos_get_shutter(int data, int dir);
-int ptp_eos_get_iso(int data, int dir);
-int ptp_eos_get_aperture(int data, int dir);
-int ptp_eos_get_white_balance(int data, int dir);
-int ptp_eos_get_imgformat_value(uint32_t data[5]);
+DLL_EXPORT int ptp_eos_get_shutter(int data, int dir);
+DLL_EXPORT int ptp_eos_get_iso(int data, int dir);
+DLL_EXPORT int ptp_eos_get_aperture(int data, int dir);
+DLL_EXPORT int ptp_eos_get_white_balance(int data, int dir);
+DLL_EXPORT int ptp_eos_get_imgformat_value(uint32_t data[5]);
 
-void *ptp_pack_chdk_upload_file(struct PtpRuntime *r, char *in, char *out, int *length);
+DLL_EXPORT void *ptp_pack_chdk_upload_file(struct PtpRuntime *r, char *in, char *out, int *length);
 
 #endif
 

--- a/src/cl_enum.h
+++ b/src/cl_enum.h
@@ -3,10 +3,10 @@
 
 #define MAX_ENUM_LENGTH 64
 
-int ptp_enum_all(char *string);
-int ptp_enum(int type, char *string);
-char *ptp_get_enum(int type, int vendor, int id);
-char *ptp_get_enum_all(int id);
+DLL_EXPORT int ptp_enum_all(char *string);
+DLL_EXPORT int ptp_enum(int type, char *string);
+DLL_EXPORT char *ptp_get_enum(int type, int vendor, int id);
+DLL_EXPORT char *ptp_get_enum_all(int id);
 
 extern char *enum_null;
 

--- a/src/cl_ops.h
+++ b/src/cl_ops.h
@@ -5,58 +5,58 @@
 /// @brief Set a generic property - abstraction over SetDeviceProp
 /// @note May reject writes if an invalid property is found (see event code)
 /// @memberof PtpRuntime
-int ptp_set_generic_property(struct PtpRuntime *r, const char *name, int value);
+DLL_EXPORT int ptp_set_generic_property(struct PtpRuntime *r, const char *name, int value);
 
 /// @brief Call before taking a picture - this is generally for 'focusing'
 /// On some cameras this does nothing.
 /// @note This is meant for a onMouseDown-like event. ptp_take_picture should be called on onMouseUp
 /// @memberof PtpRuntime
-int ptp_pre_take_picture(struct PtpRuntime *r);
+DLL_EXPORT int ptp_pre_take_picture(struct PtpRuntime *r);
 
 /// @brief Call after calling ptp_pre_take_picture - this time a picture will be taken.
 /// @memberof PtpRuntime
-int ptp_take_picture(struct PtpRuntime *r);
+DLL_EXPORT int ptp_take_picture(struct PtpRuntime *r);
 
 /// @brief Open a new session - required for most commands
 /// @memberof PtpRuntime
-int ptp_open_session(struct PtpRuntime *r);
+DLL_EXPORT int ptp_open_session(struct PtpRuntime *r);
 
 /// @memberof PtpRuntime
-int ptp_close_session(struct PtpRuntime *r);
+DLL_EXPORT int ptp_close_session(struct PtpRuntime *r);
 
 /// @memberof PtpRuntime
-int ptp_get_device_info(struct PtpRuntime *r, struct PtpDeviceInfo *di);
+DLL_EXPORT int ptp_get_device_info(struct PtpRuntime *r, struct PtpDeviceInfo *di);
 
 /// @brief Returns allocated array of storage IDs
 /// call free() afterwards
-int ptp_get_storage_ids(struct PtpRuntime *r, struct PtpArray **a);
+DLL_EXPORT int ptp_get_storage_ids(struct PtpRuntime *r, struct PtpArray **a);
 
 /// @memberof PtpRuntime
-int ptp_init_capture(struct PtpRuntime *r, int storage_id, int object_format);
+DLL_EXPORT int ptp_init_capture(struct PtpRuntime *r, int storage_id, int object_format);
 
 /// @memberof PtpRuntime
-int ptp_init_open_capture(struct PtpRuntime *r, int storage_id, int object_format);
+DLL_EXPORT int ptp_init_open_capture(struct PtpRuntime *r, int storage_id, int object_format);
 
 /// @memberof PtpRuntime
-int ptp_terminate_open_capture(struct PtpRuntime *r, int trans);
+DLL_EXPORT int ptp_terminate_open_capture(struct PtpRuntime *r, int trans);
 
 /// @memberof PtpRuntime
-int ptp_get_storage_info(struct PtpRuntime *r, int id, struct PtpStorageInfo *si);
+DLL_EXPORT int ptp_get_storage_info(struct PtpRuntime *r, int id, struct PtpStorageInfo *si);
 
 /// @memberof PtpRuntime
-int ptp_send_object_info(struct PtpRuntime *r, int storage_id, int handle, struct PtpObjectInfo *oi);
+DLL_EXPORT int ptp_send_object_info(struct PtpRuntime *r, int storage_id, int handle, struct PtpObjectInfo *oi);
 
 /// @memberof PtpRuntime
-int ptp_get_prop_value(struct PtpRuntime *r, int code);
+DLL_EXPORT int ptp_get_prop_value(struct PtpRuntime *r, int code);
 
 /// @memberof PtpRuntime
-int ptp_set_prop_value(struct PtpRuntime *r, int code, int value);
+DLL_EXPORT int ptp_set_prop_value(struct PtpRuntime *r, int code, int value);
 
 /// @memberof PtpRuntime
-int ptp_set_prop_value_data(struct PtpRuntime *r, int code, void *data, int length);
+DLL_EXPORT int ptp_set_prop_value_data(struct PtpRuntime *r, int code, void *data, int length);
 
 /// @memberof PtpRuntime
-int ptp_get_prop_desc(struct PtpRuntime *r, int code, struct PtpPropDesc *pd);
+DLL_EXPORT int ptp_get_prop_desc(struct PtpRuntime *r, int code, struct PtpPropDesc *pd);
 
 /// @brief Gets a list of object handles in a storage device or folder.
 // @param id storage ID
@@ -64,90 +64,90 @@ int ptp_get_prop_desc(struct PtpRuntime *r, int code, struct PtpPropDesc *pd);
 // @param in Can be folder object ID, or 0 for recursive (entire filesystem)
 // @param[out] a Output array is a pointer to data packet, and will be overwritten by new operations
 /// @memberof PtpRuntime
-int ptp_get_object_handles(struct PtpRuntime *r, int id, int format, int in, struct PtpArray **a);
+DLL_EXPORT int ptp_get_object_handles(struct PtpRuntime *r, int id, int format, int in, struct PtpArray **a);
 
 /// @memberof PtpRuntime
-int ptp_get_object_info(struct PtpRuntime *r, uint32_t handle, struct PtpObjectInfo *oi);
+DLL_EXPORT int ptp_get_object_info(struct PtpRuntime *r, uint32_t handle, struct PtpObjectInfo *oi);
 
 /// @memberof PtpRuntime
-int ptp_move_object(struct PtpRuntime *r, int storage_id, int handle, int folder);
+DLL_EXPORT int ptp_move_object(struct PtpRuntime *r, int storage_id, int handle, int folder);
 
 /// @memberof PtpRuntime
-int ptp_delete_object(struct PtpRuntime *r, int handle, int format_code);
+DLL_EXPORT int ptp_delete_object(struct PtpRuntime *r, int handle, int format_code);
 
 /// @brief Raw JPEG data is accessible from ptp_get_payload()
 /// @note Not thread safe.
 /// @memberof PtpRuntime
-int ptp_get_thumbnail(struct PtpRuntime *r, int handle);
+DLL_EXPORT int ptp_get_thumbnail(struct PtpRuntime *r, int handle);
 
 /// @note Not thread safe.
 /// @memberof PtpRuntime
-int ptp_get_partial_object(struct PtpRuntime *r, uint32_t handle, int offset, int max);
+DLL_EXPORT int ptp_get_partial_object(struct PtpRuntime *r, uint32_t handle, int offset, int max);
 
 /// @brief Download an object
 /// @memberof PtpRuntime
-int ptp_get_object(struct PtpRuntime *r, int handle);
+DLL_EXPORT int ptp_get_object(struct PtpRuntime *r, int handle);
 
 /// @brief Download an object from handle, to a local file (uses GetPartialObject)
 /// @memberof PtpRuntime
-int ptp_download_object(struct PtpRuntime *r, int handle, FILE *stream, size_t max);
+DLL_EXPORT int ptp_download_object(struct PtpRuntime *r, int handle, FILE *stream, size_t max);
 
 /// @brief Recieve a generic list of all properties received in DeviceInfo
 /// This is similar to getting all events, but for first startup when you know nothing.
 /// Some vendors do this, but this gets all the properties manually.
 /// @param[out] s Output structure, caller must free
 /// @memberof PtpRuntime
-int ptp_get_all_known(struct PtpRuntime *r, struct PtpGenericEvent **s, int *length);
+DLL_EXPORT int ptp_get_all_known(struct PtpRuntime *r, struct PtpGenericEvent **s, int *length);
 
 /// @note PTP/IP only
 /// @memberof PtpRuntime
-int ptpip_init_events(struct PtpRuntime *r);
+DLL_EXPORT int ptpip_init_events(struct PtpRuntime *r);
 
 /// @note PTP/IP only
 /// @memberof PtpRuntime
-int ptpip_init_command_request(struct PtpRuntime *r, char *device_name);
+DLL_EXPORT int ptpip_init_command_request(struct PtpRuntime *r, char *device_name);
 
 // EOS Only functions - not for Canon point and shoot
-int ptp_eos_get_viewfinder_data(struct PtpRuntime *r);
-int ptp_eos_set_remote_mode(struct PtpRuntime *r, int mode);
-int ptp_eos_set_prop_value(struct PtpRuntime *r, int code, int value);
-int ptp_eos_set_event_mode(struct PtpRuntime *r, int mode);
-int ptp_eos_remote_release_off(struct PtpRuntime *r, int mode);
-int ptp_eos_remote_release_on(struct PtpRuntime *r, int mode);
-int ptp_eos_get_event(struct PtpRuntime *r);
-int ptp_eos_hdd_capacity_push(struct PtpRuntime *r);
-int ptp_eos_hdd_capacity_pop(struct PtpRuntime *r);
-int ptp_eos_get_prop_value(struct PtpRuntime *r, int code);
-int ptp_eos_bulb_start(struct PtpRuntime *r);
-int ptp_eos_bulb_stop(struct PtpRuntime *r);
-int ptp_eos_set_ui_lock(struct PtpRuntime *r);
-int ptp_eos_reset_ui_lock(struct PtpRuntime *r);
-int ptp_eos_cancel_af(struct PtpRuntime *r);
+DLL_EXPORT int ptp_eos_get_viewfinder_data(struct PtpRuntime *r);
+DLL_EXPORT int ptp_eos_set_remote_mode(struct PtpRuntime *r, int mode);
+DLL_EXPORT int ptp_eos_set_prop_value(struct PtpRuntime *r, int code, int value);
+DLL_EXPORT int ptp_eos_set_event_mode(struct PtpRuntime *r, int mode);
+DLL_EXPORT int ptp_eos_remote_release_off(struct PtpRuntime *r, int mode);
+DLL_EXPORT int ptp_eos_remote_release_on(struct PtpRuntime *r, int mode);
+DLL_EXPORT int ptp_eos_get_event(struct PtpRuntime *r);
+DLL_EXPORT int ptp_eos_hdd_capacity_push(struct PtpRuntime *r);
+DLL_EXPORT int ptp_eos_hdd_capacity_pop(struct PtpRuntime *r);
+DLL_EXPORT int ptp_eos_get_prop_value(struct PtpRuntime *r, int code);
+DLL_EXPORT int ptp_eos_bulb_start(struct PtpRuntime *r);
+DLL_EXPORT int ptp_eos_bulb_stop(struct PtpRuntime *r);
+DLL_EXPORT int ptp_eos_set_ui_lock(struct PtpRuntime *r);
+DLL_EXPORT int ptp_eos_reset_ui_lock(struct PtpRuntime *r);
+DLL_EXPORT int ptp_eos_cancel_af(struct PtpRuntime *r);
 // steps can be between -3 and 3
-int ptp_eos_drive_lens(struct PtpRuntime *r, int steps);
-int ptp_eos_ping(struct PtpRuntime *r);
+DLL_EXPORT int ptp_eos_drive_lens(struct PtpRuntime *r, int steps);
+DLL_EXPORT int ptp_eos_ping(struct PtpRuntime *r);
 
 // Get max expected size of liveview, for allocations only
-int ptp_liveview_size(struct PtpRuntime *r);
+DLL_EXPORT int ptp_liveview_size(struct PtpRuntime *r);
 // Runs vendor-specific commands for the liveview
-int ptp_liveview_init(struct PtpRuntime *r);
-int ptp_liveview_deinit(struct PtpRuntime *r);
+DLL_EXPORT int ptp_liveview_init(struct PtpRuntime *r);
+DLL_EXPORT int ptp_liveview_deinit(struct PtpRuntime *r);
 // Get a frame directly into a buffer. Size is expected to be from ptp_liveview_size()
-int ptp_liveview_frame(struct PtpRuntime *r, void *buffer);
-int ptp_liveview_type(struct PtpRuntime *r);
+DLL_EXPORT int ptp_liveview_frame(struct PtpRuntime *r, void *buffer);
+DLL_EXPORT int ptp_liveview_type(struct PtpRuntime *r);
 
 // Get Magic Lantern transparent menus buffer - see https://github.com/petabyt/ptpview
-int ptp_ml_init_bmp_lv(struct PtpRuntime *r);
-int ptp_ml_get_bmp_lv(struct PtpRuntime *r, uint32_t **buffer_ptr);
+DLL_EXPORT int ptp_ml_init_bmp_lv(struct PtpRuntime *r);
+DLL_EXPORT int ptp_ml_get_bmp_lv(struct PtpRuntime *r, uint32_t **buffer_ptr);
 
-int ptp_chdk_get_version(struct PtpRuntime *r);
-int ptp_chdk_upload_file(struct PtpRuntime *r, char *input, char *dest);
+DLL_EXPORT int ptp_chdk_get_version(struct PtpRuntime *r);
+DLL_EXPORT int ptp_chdk_upload_file(struct PtpRuntime *r, char *input, char *dest);
 
 // Canon advanced extensions - available in canon-adv.c
-int ptp_eos_activate_command(struct PtpRuntime *r);
-int ptp_eos_exec_evproc(struct PtpRuntime *r, void *data, int length, int expect_return);
-int ptp_eos_evproc_run(struct PtpRuntime *r, char *fmt, ...);
-int ptp_eos_evproc_return_data(struct PtpRuntime *r);
-int ptp_eos_fa_get_build_version(struct PtpRuntime *r, char *buffer, int max);
+DLL_EXPORT int ptp_eos_activate_command(struct PtpRuntime *r);
+DLL_EXPORT int ptp_eos_exec_evproc(struct PtpRuntime *r, void *data, int length, int expect_return);
+DLL_EXPORT int ptp_eos_evproc_run(struct PtpRuntime *r, char *fmt, ...);
+DLL_EXPORT int ptp_eos_evproc_return_data(struct PtpRuntime *r);
+DLL_EXPORT int ptp_eos_fa_get_build_version(struct PtpRuntime *r, char *buffer, int max);
 
 #endif


### PR DESCRIPTION
I added the ability to build the library as dynamic if BUILD_DLL is defined (dll on Windows), if it is not defined it remains as it was.
I ported the set_nonblocking_io function so it use the native winsock.h on Windows Systems.

Unfortunately I cannot test it thoroughly now, but it should work correctly on Windows, on Linux/Unix nothing changes. 
When I use it under Pascal+Windows, soon, I will let you know.

Thanks.