### PR TITLE
docs: fix README receive typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ int main() {
 ```
 Calling a custom opcode:
 ```
-// Send a command, and recieve packet(s)
+// Send a command, and receive packet(s)
 struct PtpCommand cmd;
 cmd.code = 0x1234;
 cmd.param_length = 3;


### PR DESCRIPTION
## Summary
- Correct one README spelling typo: `recieve` -> `receive`.

## Validation
- `rg -n 'recieve|receive|Send a command' README.md`\n- `git diff --check`\n\nNo code or behavior changes.